### PR TITLE
Transitions and Durations panels (#15)

### DIFF
--- a/src/components/panel-list.vue
+++ b/src/components/panel-list.vue
@@ -61,6 +61,18 @@
 			type: 'Sources'
 		},
 		{
+			name: 'Set Transition',
+			description: 'Set the current transition',
+			icon: 'blur_linear',
+			type: 'Transitions'
+		},
+		{
+			name: 'Set Duration',
+			description: 'Set the current duration',
+			icon: 'timelapse',
+			type: 'Durations'
+		},
+		{
 			name: 'Stream Status',
 			description: 'Manage stream & recording status',
 			icon: 'movie',

--- a/src/components/panels/durations.vue
+++ b/src/components/panels/durations.vue
@@ -1,0 +1,48 @@
+<template>
+	<panel-wrapper :content-class="['panel-durations']">
+		<template slot="name">Durations</template>
+		<h3 class="current-duration">{{ currentDuration }}ms</h3>
+		<div class="durations" v-if="allDurations">
+			<button
+				class="duration"
+				v-for="duration in allDurations"
+				:class="[duration === currentDuration ? 'is-active' : 'is-inactive']"
+				:key="duration"
+				@click="changeDuration(duration)">{{ duration }}ms</button>
+		</div>
+	</panel-wrapper>
+</template>
+
+<script>
+import {mapState, mapActions} from 'vuex'
+import panelMixin from '../mixins/panel'
+
+export default {
+	mixins: [panelMixin],
+
+	data() {
+		const data = {
+			staticDurations: [{duration: 100}, {duration: 300}, {duration: 600}, {duration: 1000}, {duration: 1500}]
+			// Static durations logrithmic in nature
+		}
+		return data
+	},
+
+	computed: {
+		...mapState('obs', {
+			currentDuration: state => state.durations.current,
+			allDurations: state => state.durations.list
+		})
+	},
+
+	methods: {
+		async changeDuration(ms) {
+			await this.setDuration({ms})
+		},
+		...mapActions('obs', {
+			setDuration: 'durations/current'
+		})
+	}
+}
+
+</script>

--- a/src/components/panels/index.js
+++ b/src/components/panels/index.js
@@ -7,6 +7,8 @@ import Invalid from './invalid'
 import Scenes from './scenes'
 import Sources from './sources'
 import Stream from './stream'
+import Transitions from './transitions'
+import Durations from './durations'
 
 const components = {
 	Grid,
@@ -14,6 +16,8 @@ const components = {
 	Invalid,
 	Scenes,
 	Sources,
+	Transitions,
+	Durations,
 	Stream
 }
 

--- a/src/components/panels/transitions.vue
+++ b/src/components/panels/transitions.vue
@@ -1,0 +1,44 @@
+<template>
+	<panel-wrapper :content-class="['panel-transitions']">
+		<template slot="name">Transitions</template>
+		<div class="transitions" v-if="allTransitions">
+			<button
+				class="transition"
+				v-for="transition in allTransitions"
+				:key="transition.name"
+				:class="[transition.name === currentTransition ? 'is-active' : 'is-inactive']"
+				@click="switchTransitions(transition.name)"
+				v-text="transition.name"></button>
+		</div>
+		<div v-else>
+			Transition list is empty! Should minimally have 'Cut' and 'Fade' ... Something is wrong :(
+		</div>
+	</panel-wrapper>
+</template>
+
+<script>
+import {mapState, mapActions} from 'vuex'
+import panelMixin from '../mixins/panel'
+
+export default {
+
+	mixins: [panelMixin],
+
+	computed: {
+		...mapState('obs', {
+			currentTransition: state => state.transitions.current,
+			allTransitions: state => state.transitions.list
+		})
+	},
+
+	methods: {
+		async switchTransitions(name) {
+			await this.setTransition({name})
+		},
+		...mapActions('obs', {
+			setTransition: 'transitions/current'
+		})
+	}
+}
+
+</script>

--- a/src/store/plugins/obs/module/durations.js
+++ b/src/store/plugins/obs/module/durations.js
@@ -1,0 +1,38 @@
+export default {
+	state: {
+		// Static/initial durations logrithmic in nature
+		list: [100, 300, 600, 1000, 1500],
+		current: null
+	},
+	actions: {
+		'connection/closed'({commit}) {
+			commit('transitions/reset')
+		},
+		'connection/ready'({dispatch}) {
+			return dispatch('durations/reload')
+		},
+		async 'durations/reload'({commit, getters: {client}}) {
+			const {'transition-duration': duration} = await client.send({'request-type': 'GetTransitionDuration'})
+
+			commit('durations/current', {duration})
+		},
+		'durations/current'({getters: {client}}, {ms}) {
+			return client.send({'request-type': 'SetTransitionDuration', 'duration': ms})
+		},
+		'event/TransitionDurationChanged'({commit}, data) {
+			commit('durations/durationChanged', data)
+		}
+	},
+	mutations: {
+		'durations/current'(state, {duration}) {
+			state.current = duration
+		},
+		'durations/reset'(state) {
+			state.list = [100, 300, 600, 1000, 1500]
+			state.current = null
+		},
+		'durations/durationChanged'(state, {'new-duration': newDuration}) {
+			state.current = newDuration
+		}
+	}
+}

--- a/src/store/plugins/obs/module/transitions.js
+++ b/src/store/plugins/obs/module/transitions.js
@@ -1,0 +1,49 @@
+export default {
+	state: {
+		current: null,
+		list: []
+	},
+	actions: {
+		'connection/closed'({commit}) {
+			commit('transitions/reset')
+		},
+		'connection/ready'({dispatch}) {
+			return dispatch('transitions/reload')
+		},
+		async 'transitions/reload'({commit, getters: {client}}) {
+			const {'current-transition': current, transitions} = await client.send({'request-type': 'GetTransitionList'})
+
+			commit('transitions/list', {transitions})
+			commit('transitions/current', {
+				'current-transition': current
+			})
+		},
+		'transitions/current'({getters: {client}}, {name}) {
+			return client.send({'request-type': 'SetCurrentTransition', 'transition-name': name})
+		},
+		'event/SwitchTransition'({commit}, data) {
+			commit('transitions/newcurrent', data)
+		},
+		'event/TransitionListChanged'({dispatch}) {
+			return dispatch('transitions/reload')
+		},
+		'event/TransitionBegin'({commit}, data) {
+			// Do I do anything or simple discard for now?!
+		}
+	},
+	mutations: {
+		'transitions/current'(state, {'current-transition': name}) {
+			state.current = name
+		},
+		'transitions/newcurrent'(state, {'transition-name': name}) {
+			state.current = name
+		},
+		'transitions/list'(state, {transitions}) {
+			state.list = transitions
+		},
+		'transitions/reset'(state) {
+			state.current = null
+			state.list = []
+		}
+	}
+}

--- a/src/store/plugins/obs/modules.js
+++ b/src/store/plugins/obs/modules.js
@@ -1,7 +1,11 @@
 import scenes from './module/scenes'
 import stream from './module/stream'
+import transitions from './module/transitions'
+import durations from './module/durations'
 
 export default {
 	scenes,
-	stream
+	stream,
+	transitions,
+	durations
 }

--- a/src/stylesheets/app.scss
+++ b/src/stylesheets/app.scss
@@ -31,6 +31,8 @@ html {
 @import "panels/scenes";
 @import "panels/sources";
 @import "panels/stream";
+@import "panels/transitions";
+@import "panels/durations";
 
 @import "pages/connect";
 @import "pages/dashboard";

--- a/src/stylesheets/panels/_durations.scss
+++ b/src/stylesheets/panels/_durations.scss
@@ -1,0 +1,23 @@
+.panel-durations {
+	display: flex;
+	flex-direction: column;
+
+	& > .current-duration {
+			text-align: center;
+		}
+
+	& > .durations {
+		display: flex;
+		flex-direction: column;
+		flex: 1 1 auto;
+		overflow-y: auto;
+
+		& > .duration {
+			border: none;
+			flex: 0 0 auto;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+	}
+}

--- a/src/stylesheets/panels/_transitions.scss
+++ b/src/stylesheets/panels/_transitions.scss
@@ -1,0 +1,23 @@
+.panel-transitions {
+	display: flex;
+	flex-direction: column;
+
+	& > .transitions-list {
+			text-align: center;
+		}
+
+	& > .transitions {
+		display: flex;
+		flex-direction: column;
+		flex: 1 1 auto;
+		overflow-y: auto;
+
+		& > .transition {
+			border: none;
+			flex: 0 0 auto;
+			overflow: hidden;
+			text-overflow: ellipsis;
+			white-space: nowrap;
+		}
+	}
+}


### PR DESCRIPTION
* Creates and intergates a new transition panel (currently with static durations) -- perhaps somebody will add a config
Still minor issue with getting initial duration at load/ready

* Cleanup (original was thinking Quick Transition list in Broadcast "mode" -- but that is unavailable via obs-websocket)

* ran some linting and cleaning

* removing something not needed any more from scss source

* broke durations from transitions into seperate panel.
 - still has loading current duration at startup issue
 - still uses an array of objects with one property 'duration' (will tackle that next)

* Fix getting current duration on startup

* changed array of objects with duration property into array of int

* Cleanup at some lint removal

* updated (a second time) transitions and durations icons

* correction,  blur_linear and timelapse

* fix issue (reloading instead of update current name)

* dusting some lint